### PR TITLE
fixed ShootCommand (groovy) test

### DIFF
--- a/web-ui/src/test/java/org/axonframework/samples/trader/test/CommandCreator.groovy
+++ b/web-ui/src/test/java/org/axonframework/samples/trader/test/CommandCreator.groovy
@@ -21,6 +21,7 @@ import org.axonframework.samples.trader.orders.api.transaction.StartSellTransact
 import org.axonframework.samples.trader.query.portfolio.PortfolioEntry
 import org.axonframework.samples.trader.tradeengine.api.order.OrderBookId
 import org.axonframework.samples.trader.tradeengine.api.order.PortfolioId
+import org.axonframework.samples.trader.tradeengine.api.order.TransactionId;
 
 /**
  * Class used to create an order based on the provided Profile. If the profile has money we place buy orders, if
@@ -40,6 +41,7 @@ class CommandCreator {
     def createCommand(PortfolioEntry portfolio) {
         if (portfolio.amountOfMoney - portfolio.reservedAmountOfMoney > 10000) {
             command = new StartBuyTransactionCommand(
+					new TransactionId(),
                     new OrderBookId(obtainRandomOrderBook()),
                     new PortfolioId(portfolio.identifier),
                     randomFactory.nextInt(50) + 1,
@@ -48,6 +50,7 @@ class CommandCreator {
             def availableOrderBook = obtainAvailableOrderBook(portfolio)
             if (availableOrderBook) {
                 command = new StartSellTransactionCommand(
+						new TransactionId(),
                         new OrderBookId(availableOrderBook[0]),
                         new PortfolioId(portfolio.identifier),
                         availableOrderBook[1],

--- a/web-ui/src/test/java/org/axonframework/samples/trader/test/CommandSender.groovy
+++ b/web-ui/src/test/java/org/axonframework/samples/trader/test/CommandSender.groovy
@@ -28,7 +28,7 @@ import org.axonframework.samples.trader.query.portfolio.PortfolioEntry
  * @author Jettro Coenradie
  */
 class CommandSender {
-    def http = new HTTPBuilder('http://localhost:8080/trader/')
+    def http = new HTTPBuilder('http://localhost:8080/')
     def requestContentType = ContentType.URLENC
     XStream xStream = new XStream()
 

--- a/web-ui/src/test/java/org/axonframework/samples/trader/test/ShootCommand.groovy
+++ b/web-ui/src/test/java/org/axonframework/samples/trader/test/ShootCommand.groovy
@@ -50,7 +50,7 @@ for (int i = 0; i < 1000; i++) {
     PortfolioEntry portfolio = commandSender.obtainPortfolio(portfolioIdentifier)
     def command = commandCreator.createCommand(portfolio)
 
-    println "${portfolio.userName} # ${command.tradeCount} \$ ${command.itemPrice} ${companyNames[command.orderbookIdentifier.asString()]}"
+    println "${portfolio.userName} # ${command.tradeCount} \$ ${command.itemPrice} ${companyNames[command.orderbookIdentifier.toString()]}"
 
     commandSender.sendCommand(command)
 


### PR DESCRIPTION
Some minor fixes to make the groovy tests succeed again:
- pass a new TransactionId to the StartBuyTransactionCommand and StartSellTransactionCommand
- orderbookIdentifier.toString() instead of orderbookIdentifier.asString()
- connect to http://localhost:8080/ instead of http://localhost:8080/trader
